### PR TITLE
Rework the license guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1966,9 +1966,23 @@ impl From<other_crate::Error> for Error {
 <a id="c-permissive"></a>
 ### Crate and its dependencies have a permissive license (C-PERMISSIVE)
 
-TL;DR the Rust ecosystem is largely Apache-2.0. Being available under that
-license is good for interoperation. The MIT license as an add-on can be nice for
-GPLv2 projects to use your code.
+The software produced by the Rust project is dual-licensed, under
+either the [MIT] or [Apache 2.0] licenses. Crates that simply need the
+maximum compatibility with the Rust ecosystem are recommended to do
+the same, in the manner described herein. Other options are described
+below.
+
+These API guidelines do not provide a detailed explanation of Rust's
+license, but there is a small amount said in the [Rust FAQ]. These
+guidelines are concerned with matters of interoperability with Rust,
+and are not comprehensive over licensing options.
+
+[MIT]: https://github.com/rust-lang/rust/blob/master/LICENSE-MIT
+[Apache 2.0]: https://github.com/rust-lang/rust/blob/master/LICENSE-APACHE
+[Rust FAQ]: https://www.rust-lang.org/en-US/faq.html#why-a-dual-mit-asl2-license
+
+To apply the Rust license to your project, define the `license` field
+in your `Cargo.toml` as:
 
 ```toml
 [package]
@@ -1978,27 +1992,7 @@ authors = ["..."]
 license = "MIT/Apache-2.0"
 ```
 
-The MIT license requires reproducing countless copies of the same copyright
-header with different names in the copyright field, for every MIT library in
-use. The Apache license does not have this drawback. The Apache license also has
-protections from patent trolls and an explicit contribution licensing clause.
-However, the Apache license is incompatible with GPLv2. This is why Rust is
-dual-licensed as MIT/Apache (the "primary" license being Apache, MIT only for
-GPLv2 compat). This also makes a crate suitable for inclusion and unrestricted
-sharing in the Rust standard distribution and other projects using dual
-MIT/Apache.
-
-Some ask, "Does this really apply to binary redistributions? Does MIT really
-require reproducing the whole thing?" I'm not a lawyer, and I can't give legal
-advice, but some Google Android apps include open source attributions using this
-interpretation. [Others also agree with it]. But, again, the copyright notice
-redistribution is not the primary motivation for the dual-licensing. It's
-stronger protections to licensees and better interoperation with the wider Rust
-ecosystem.
-
-[Others also agree with it]: https://www.quora.com/Does-the-MIT-license-require-attribution-in-a-binary-only-distribution
-
-A dual-licensed crate should have the following in its readme:
+And toward the end of your README.md:
 
 ```
 ## License
@@ -2019,25 +2013,21 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 ```
 
-And license headers, if you have them, should use the following boilerplate
-(based on that used in Rust):
+Besides the dual MIT/Apache-2.0 license, another common licensing approach
+used by Rust crate authors is to apply a single permissive license such as
+MIT or BSD. This license scheme is also entirely compatible with Rust's,
+because it imposes the minimal restrictions of Rust's MIT license.
 
-```
-// Copyright 2016 (YOUR PROJECT) Developers
-//
-// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
-// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. This file may not be
-// copied, modified, or distributed except according to those terms.
-```
+Crates that desire perfect license compatibility with Rust are not
+recommended to choose only the Apache license. The Apache license,
+though it is a permissive license, imposes restrictions beyond the MIT
+and BSD licenses that can discourage or prevent their use in some
+scenarios, so Apache-only software cannot be used in some situations
+where most of the Rust runtime stack can.
 
-It's commonly asked whether license headers are required. I'm not comfortable
-making an official recommendation either way, but the Apache license recommends
-it in their appendix on how to use the license.
-
-Be sure to add the relevant LICENSE-{MIT,APACHE} files. You can copy these from
-the [Rust](https://github.com/rust-lang/rust) repo for a plain-text version.
-
+The license of a crate's dependencies can affect the restrictions on
+distribution of the crate itself, so a permissively-licensed crate
+should generally only depend on permissively-licensed crates.
 
 <a id="external-links"></a>
 ## External Links


### PR DESCRIPTION
This is more accurate to my understanding of Rust licensing, and is
representative of the approach we have taken.

I removed most analysis of the license and left it an explanation of
how to pick a license that is compatible with Rust.

This flips the recommendation about MIT vs. Apache. MIT is the less
restrictive license and is more compatible with Rust than Apache. We
don't accept Apache only software in rust-lang projects, but we do
accept MIT-only.

It also removes discussion of license headers. They were a mistake in Rust
and just confuse the issue.

r? @dtolnay 

I'd like to land this before publicizing the guidelines.

cc @aturon